### PR TITLE
add renovatebot to update dependencies

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,24 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: [
+    "config:recommended",
+    ":maintainLockFilesMonthly",
+  ],
+  packageRules: [
+    {
+      matchCategories: ["rust"],
+      updateTypes: ["patch"],
+      // Disable patch updates for single dependencies because patches
+      // are updated periodically with lockfile maintainance.
+      enabled: false,
+    },
+  ],
+  // Receive any update that fixes security vulnerabilities.
+  // We need this because we disabled "patch" updates for Rust.
+  // Note: You need to enable "Dependabot alerts" in "Code security" GitHub
+  // Settings to receive security updates.
+  // See https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts
+  vulnerabilityAlerts: {
+    enabled: true,
+  },
+}


### PR DESCRIPTION
Closes https://github.com/rust-lang/generate-manifest-list/issues/4

Adding renovatebot will keep the repository active so that GitHub doesn't disable the scheduled workflow.

Based on https://github.com/rust-lang/bors/blob/main/.github/renovate.json5
Discussed in [zulip](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/manifests.2Etxt.20stopped.20working.20on.202024-12-29/near/498086172).