### PR TITLE
Keep the cronjob alive

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -5,6 +5,9 @@ on:
     schedule:
         - cron: "0 6 * * 1" # every week
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -24,3 +27,19 @@ jobs:
           AWS_ACCESS_KEY_ID: AKIA46X5W6CZLETGWKHR
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: us-west-1
+
+  keep-alive:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      # We don't often commit to this repository, and without any activity GitHub Actions will
+      # disable scheduled workflows after 60 days. It turns out that calling the "enable" API even
+      # before the workflow is disabled resets the 60 days counter though!
+      #
+      # Inspired by https://github.com/liskin/gh-workflow-keepalive/blob/main/action.yml
+      - name: Call the GitHub API
+        run: |
+          curl "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/cron.yml/enable" -H "Authorization: token ${GITHUB_TOKEN}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
It was reported in the community Discord server that the GitHub Actions cronjob generating the manifest list was disabled due to inactivity in the report. I [pushed a commit](https://github.com/rust-lang/generate-manifest-list/commit/c60d245a8139d64baaba1282a7d9d20d7f75abf9) to unblock it, but that would just delay the problem by two months.

Looking around for a solution, I discovered that calling the "enable workflow" API (even when the workflow is still enabled) resets the two months counter, without having to clutter the repository with empty commits. This PR implements that, hopefully preventing the workflow from being disabled in the future.