### PR TITLE
Actually make keepalive work

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -40,6 +40,6 @@ jobs:
       # Inspired by https://github.com/liskin/gh-workflow-keepalive/blob/main/action.yml
       - name: Call the GitHub API
         run: |
-          curl "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/cron.yml/enable" -H "Authorization: token ${GITHUB_TOKEN}"
+          curl -X PUT "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/cron.yml/enable" -H "Authorization: token ${GITHUB_TOKEN}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The API docs say PUT, and if you look at the log you can see that it has never actually worked.

I know this is made redundant with https://github.com/rust-lang/promote-release/pull/89 but @pietroalbini still wanted me to make the PR. 